### PR TITLE
fix: skip to stop BGM when announce file is not founded

### DIFF
--- a/src/vehicle_voice_alert_system/src/vehicle_voice_alert_system/announce_controller.py
+++ b/src/vehicle_voice_alert_system/src/vehicle_voice_alert_system/announce_controller.py
@@ -174,13 +174,14 @@ class AnnounceControllerProperty:
             self._node.get_logger().error("not able to check the current playing: " + str(e))
 
     def play_sound(self, message):
-        if self._mute_overlap_bgm and self._music_object and self._music_object.is_playing():
-            self._music_object.stop()
-
         if path.exists("{}/{}.wav".format(self._primary_voice_folder_path, message)):
+            if self._mute_overlap_bgm and self._music_object and self._music_object.is_playing():
+                self._music_object.stop()
             sound = WaveObject.from_wave_file("{}/{}.wav".format(self._primary_voice_folder_path, message))
             self._wav_object = sound.play()
         elif not self._skip_default_voice:
+            if self._mute_overlap_bgm and self._music_object and self._music_object.is_playing():
+                self._music_object.stop()
             sound = WaveObject.from_wave_file("{}/{}.wav".format(self._package_path, message))
             self._wav_object = sound.play()
         else:

--- a/src/vehicle_voice_alert_system/src/vehicle_voice_alert_system/announce_controller.py
+++ b/src/vehicle_voice_alert_system/src/vehicle_voice_alert_system/announce_controller.py
@@ -179,11 +179,12 @@ class AnnounceControllerProperty:
                 self._music_object.stop()
             sound = WaveObject.from_wave_file("{}/{}.wav".format(self._primary_voice_folder_path, message))
             self._wav_object = sound.play()
-        elif not self._skip_default_voice:
-            if self._mute_overlap_bgm and self._music_object and self._music_object.is_playing():
-                self._music_object.stop()
-            sound = WaveObject.from_wave_file("{}/{}.wav".format(self._package_path, message))
-            self._wav_object = sound.play()
+        elif path.exists("{}/{}.wav".format(self._package_path, message)):
+            if not self._skip_default_voice:
+                if self._mute_overlap_bgm and self._music_object and self._music_object.is_playing():
+                    self._music_object.stop()
+                sound = WaveObject.from_wave_file("{}/{}.wav".format(self._package_path, message))
+                self._wav_object = sound.play()
         else:
             self._node.get_logger().info("Didn't found the voice in the primary voice folder, and skip default voice is enabled")
 


### PR DESCRIPTION
## PR Type

<!-- Select one and remove others. If an appropriate one is not listed, please write by yourself. -->

- Improvement

## Related Links

<!-- Please write related links to GitHub/Jira/Slack/etc. -->

## Description

音声ファイルが見つからなかった場合、発話をスキップするがBGMの中断も行わないようにする

<!-- Describe what this PR changes. -->

## Review Procedure

<!-- Explain how to review this PR. -->

## Remarks

<!-- Write remarks as you like if you need them. -->

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [x] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] (Optional) Unit tests have been written for new behavior
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets
- [ ] Write release notes

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
