### PR TITLE
feat(start announce): add initialize when autoware restart

### DIFF
--- a/src/vehicle_voice_alert_system/src/vehicle_voice_alert_system/announce_controller.py
+++ b/src/vehicle_voice_alert_system/src/vehicle_voice_alert_system/announce_controller.py
@@ -32,6 +32,7 @@ class AnnounceControllerProperty:
         autoware_state_interface.set_stop_reason_callback(self.sub_stop_reason)
         autoware_state_interface.set_velocity_callback(self.sub_velocity)
         autoware_state_interface.set_motion_state_callback(self.sub_motion_state)
+        autoware_state_interface.set_localization_initialization_state_callback(self.sub_localization_initialization_state)
 
         self._node = node
         self._ros_service_interface = ros_service_interface
@@ -313,3 +314,8 @@ class AnnounceControllerProperty:
 
     def sub_motion_state(self, motion_state):
         self._current_motion_state = motion_state
+
+    def sub_localization_initialization_state(self, initialization_state):
+        if initialization_state == 1:
+            self._current_motion_state = 0
+            self._prev_motion_state = 0


### PR DESCRIPTION
## PR Type

<!-- Select one and remove others. If an appropriate one is not listed, please write by yourself. -->

- Bug Fix

## Related Links

<!-- Please write related links to GitHub/Jira/Slack/etc. -->

## Description

Autowareのみを再起動したとき車外向け音声案内にmotion stateの値がそのままになっていたためAutoware起動時に発信しますという発話をしてしまうことがありました
Autoware起動時（自己位置がuninitializedになったとき）にmotion stateの値をリセットするようにしました

TODO:
- Autoware起動時にmotion stateが3(出発)の値を送るバグを修正する
- Autowareが再起動したことを検知した場合、他のリセットするべき値をリセットする


<!-- Describe what this PR changes. -->

## Review Procedure

<!-- Explain how to review this PR. -->

## Remarks

<!-- Write remarks as you like if you need them. -->

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [x] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] (Optional) Unit tests have been written for new behavior
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets
- [ ] Write release notes

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
