### PR TITLE
hotfix: 緊急停止表示条件の追加と緊急停止時の一時停止・障害物停止発話のキャンセル

### DIFF
--- a/src/vehicle_voice_alert_system/src/vehicle_voice_alert_system/announce_controller.py
+++ b/src/vehicle_voice_alert_system/src/vehicle_voice_alert_system/announce_controller.py
@@ -248,7 +248,10 @@ class AnnounceControllerProperty:
         self._current_announce = message
 
     def emergency_checker_callback(self):
-        in_emergency = self._autoware.information.mrm_behavior == MrmState.EMERGENCY_STOP
+        in_emergency = (
+            self._autoware.information.mrm_behavior == MrmState.EMERGENCY_STOP
+            or self._autoware.information.mrm_behavior == MrmState.COMFORTABLE_STOP
+        )
 
         if in_emergency and not self._in_emergency_state:
             self.send_announce("emergency")
@@ -278,6 +281,10 @@ class AnnounceControllerProperty:
             self._node.get_logger().warning(
                 "The vehicle is not in driving state, do not announce", throttle_duration_sec=10
             )
+            return
+
+        # skip when emergency stop
+        if self._in_emergency_state:
             return
 
         stop_reasons = self._autoware.information.stop_reasons


### PR DESCRIPTION
## PR Type

<!-- Select one and remove others. If an appropriate one is not listed, please write by yourself. -->

- Bug Fix

## Related Links

<!-- Please write related links to GitHub/Jira/Slack/etc. -->

## Description

MRMのCOMFORTABLE_STOP時にも緊急停止表示を行うようにする
緊急停止時は一時停止・障害物停止の発話を行わないようにする

<!-- Describe what this PR changes. -->

## Review Procedure

- 下記を実行したときに緊急停止表示になる
  - ros2 topic pub /api/fail_safe/mrm_state autoware_adapi_v1_msgs/msg/MrmState "{state: 2, behavior: 3}" -1
- 障害物で停止しているときに緊急停止状態にし、障害物発話を行わないかを確認する

<!-- Explain how to review this PR. -->

## Remarks

<!-- Write remarks as you like if you need them. -->

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [x] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] (Optional) Unit tests have been written for new behavior
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets
- [ ] Write release notes

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
