### PR TITLE
hotfix: skip_announceを判定するロジック修正

### DIFF
--- a/src/vehicle_voice_alert_system/src/vehicle_voice_alert_system/announce_controller.py
+++ b/src/vehicle_voice_alert_system/src/vehicle_voice_alert_system/announce_controller.py
@@ -198,7 +198,7 @@ class AnnounceControllerProperty:
                 in [MotionState.STARTING, MotionState.MOVING]
                 and self._prev_motion_state == 1
             ):
-                if self._announce_engage and not self._skip_announce:
+                if not self._skip_announce:
                     self._skip_announce = True
                 else:
                     self.send_announce("departure")


### PR DESCRIPTION
## PR Type

<!-- Select one and remove others. If an appropriate one is not listed, please write by yourself. -->

- Improvement

## Related Links

<!-- Please write related links to GitHub/Jira/Slack/etc. -->

## Description

_announce_engageは入れなくてもいいかと思いました
こちらがあるとBus Stopがない場合の発進時に先にmotion stateが更新されてしまってフラグが更新されないことがあります

motion state更新 -> operation mode更新 -> 通常の一時停止線で停止後、発話しない

となることがあります

<!-- Describe what this PR changes. -->

## Review Procedure

<!-- Explain how to review this PR. -->

## Remarks

<!-- Write remarks as you like if you need them. -->

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [ ] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] (Optional) Unit tests have been written for new behavior
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets
- [ ] Write release notes

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
